### PR TITLE
Remove unused auth table on users

### DIFF
--- a/docs/core/users.md
+++ b/docs/core/users.md
@@ -10,7 +10,6 @@ between these users and reddit accounts.
    Column   |            Type             | Collation | Nullable |              Default              | Storage  | Stats target | Description
 ------------+-----------------------------+-----------+----------+-----------------------------------+----------+--------------+-------------
  id         | integer                     |           | not null | nextval('users_id_seq'::regclass) | plain    |              |
- auth       | integer                     |           | not null | 0                                 | plain    |              |
  username   | character varying(63)       |           | not null |                                   | extended |              |
  created_at | timestamp without time zone |           | not null | CURRENT_TIMESTAMP                 | plain    |              |
  updated_at | timestamp without time zone |           | not null | CURRENT_TIMESTAMP                 | plain    |              |

--- a/src/migrations/005_delete_auth_on_users.py
+++ b/src/migrations/005_delete_auth_on_users.py
@@ -1,0 +1,15 @@
+"""Deletes the auth column on users which is unused"""
+
+
+def up(conn, cursor):
+    cursor.execute(
+        'ALTER TABLE users DROP COLUMN auth'
+    )
+    print(cursor.query.decode('utf-8'))
+
+
+def down(conn, cursor):
+    cursor.execute(
+        'ALTER TABLE users ADD COLUMN auth INTEGER NOT NULL DEFAULT 0'
+    )
+    print(cursor.query.decode('utf-8'))

--- a/tests/migrations/005_delete_auth_on_users_down.py
+++ b/tests/migrations/005_delete_auth_on_users_down.py
@@ -1,0 +1,27 @@
+import unittest
+import helper
+
+
+class DownTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.connection = helper.setup_connection()
+        cls.cursor = cls.connection.cursor()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.cursor.close()
+        cls.connection.rollback()
+        helper.teardown_connection(cls.connection)
+
+    def tearDown(self):
+        self.connection.rollback()
+
+    def test_auth_on_users_does_exist(self):
+        self.assertTrue(
+            helper.check_if_column_exist(self.cursor, 'users', 'auth')
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/migrations/005_delete_auth_on_users_up.py
+++ b/tests/migrations/005_delete_auth_on_users_up.py
@@ -1,0 +1,27 @@
+import unittest
+import helper
+
+
+class UpTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.connection = helper.setup_connection()
+        cls.cursor = cls.connection.cursor()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.cursor.close()
+        cls.connection.rollback()
+        helper.teardown_connection(cls.connection)
+
+    def tearDown(self):
+        self.connection.rollback()
+
+    def test_auth_on_users_does_not_exist(self):
+        self.assertFalse(
+            helper.check_if_column_exist(self.cursor, 'users', 'auth')
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This was initially added because it's how auth used to work, but we won't need it with the permissions system