### PR TITLE
Allow specifying migrations.json path in envvar

### DIFF
--- a/src/run_migrations.py
+++ b/src/run_migrations.py
@@ -7,7 +7,7 @@ import psycopg2
 import settings
 
 
-MIGRATIONS_PATH = 'migrations.json'
+MIGRATIONS_PATH = os.environ.get('MIGRATIONS_PATH', 'migrations.json')
 
 
 def main(migrations_dir='migrations'):


### PR DESCRIPTION
On AWS it's annoying if this is in the src folder as that
gets deleted on uploads