### PR TITLE
Add response descriptions

### DIFF
--- a/docs/audit/response_histories.md
+++ b/docs/audit/response_histories.md
@@ -16,6 +16,8 @@ historical reference.
  new_raw     | text                        |           | not null |                                                | extended |              |
  reason      | text                        |           | not null |                                                | extended |              |
  created_at  | timestamp without time zone |           | not null | now()                                          | plain    |              |
+ old_desc    | text                        |           | not null |                                                | extended |              |
+ new_desc    | text                        |           | not null |                                                | extended |              |
 Indexes:
     "response_histories_pkey" PRIMARY KEY, btree (id)
     "idx_resp_hists_resp_id" btree (response_id)

--- a/docs/core/responses.md
+++ b/docs/core/responses.md
@@ -18,6 +18,7 @@ There is a history table described at `audit/response_histories`
  response_body | text                        |           | not null |                                       | extended |              |
  created_at    | timestamp without time zone |           | not null | now()                                 | plain    |              |
  updated_at    | timestamp without time zone |           | not null | now()                                 | plain    |              |
+ description   | text                        |           | not null |                                       | extended |              |
 Indexes:
     "responses_pkey" PRIMARY KEY, btree (id)
     "responses_name_key" UNIQUE CONSTRAINT, btree (name)

--- a/src/migrations/008_add_desc_to_responses.py
+++ b/src/migrations/008_add_desc_to_responses.py
@@ -1,0 +1,15 @@
+"""Adds the description column to the responses table"""
+
+
+def up(conn, cursor):
+    cursor.execute(
+        'ALTER TABLE responses ADD COLUMN description TEXT NOT NULL'
+    )
+    print(cursor.query.decode('utf-8'))
+
+
+def down(conn, cursor):
+    cursor.execute(
+        'ALTER TABLE responses DROP COLUMN description'
+    )
+    print(cursor.query.decode('utf-8'))

--- a/src/migrations/008_add_desc_to_responses.py
+++ b/src/migrations/008_add_desc_to_responses.py
@@ -7,9 +7,29 @@ def up(conn, cursor):
     )
     print(cursor.query.decode('utf-8'))
 
+    cursor.execute(
+        'ALTER TABLE response_histories ADD COLUMN old_desc TEXT NOT NULL'
+    )
+    print(cursor.query.decode('utf-8'))
+
+    cursor.execute(
+        'ALTER TABLE response_histories ADD COLUMN new_desc TEXT NOT NULL'
+    )
+    print(cursor.query.decode('utf-8'))
+
 
 def down(conn, cursor):
     cursor.execute(
         'ALTER TABLE responses DROP COLUMN description'
+    )
+    print(cursor.query.decode('utf-8'))
+
+    cursor.execute(
+        'ALTER TABLE response_histories DROP COLUMN old_desc'
+    )
+    print(cursor.query.decode('utf-8'))
+
+    cursor.execute(
+        'ALTER TABLE response_histories DROP COLUMN new_desc'
     )
     print(cursor.query.decode('utf-8'))

--- a/tests/migrations/008_add_desc_to_responses_down.py
+++ b/tests/migrations/008_add_desc_to_responses_down.py
@@ -22,6 +22,16 @@ class DownTest(unittest.TestCase):
             helper.check_if_column_exist(self.cursor, 'responses', 'description')
         )
 
+    def test_response_hist_old_desc_dne(self):
+        self.assertFalse(
+            helper.check_if_column_exist(self.cursor, 'responses', 'old_desc')
+        )
+
+    def test_response_hist_new_desc_dne(self):
+        self.assertFalse(
+            helper.check_if_column_exist(self.cursor, 'responses', 'new_desc')
+        )
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/migrations/008_add_desc_to_responses_down.py
+++ b/tests/migrations/008_add_desc_to_responses_down.py
@@ -24,12 +24,12 @@ class DownTest(unittest.TestCase):
 
     def test_response_hist_old_desc_dne(self):
         self.assertFalse(
-            helper.check_if_column_exist(self.cursor, 'responses', 'old_desc')
+            helper.check_if_column_exist(self.cursor, 'response_histories', 'old_desc')
         )
 
     def test_response_hist_new_desc_dne(self):
         self.assertFalse(
-            helper.check_if_column_exist(self.cursor, 'responses', 'new_desc')
+            helper.check_if_column_exist(self.cursor, 'response_histories', 'new_desc')
         )
 
 

--- a/tests/migrations/008_add_desc_to_responses_down.py
+++ b/tests/migrations/008_add_desc_to_responses_down.py
@@ -1,0 +1,27 @@
+import unittest
+import helper
+
+
+class DownTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.connection = helper.setup_connection()
+        cls.cursor = cls.connection.cursor()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.cursor.close()
+        cls.connection.rollback()
+        helper.teardown_connection(cls.connection)
+
+    def tearDown(self):
+        self.connection.rollback()
+
+    def test_response_desc_dne(self):
+        self.assertFalse(
+            helper.check_if_column_exist(self.cursor, 'responses', 'description')
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/migrations/008_add_desc_to_responses_up.py
+++ b/tests/migrations/008_add_desc_to_responses_up.py
@@ -22,6 +22,16 @@ class UpTest(unittest.TestCase):
             helper.check_if_column_exist(self.cursor, 'responses', 'description')
         )
 
+    def test_response_hist_old_desc_exists(self):
+        self.assertTrue(
+            helper.check_if_column_exist(self.cursor, 'responses', 'old_desc')
+        )
+
+    def test_response_hist_new_desc_exists(self):
+        self.assertTrue(
+            helper.check_if_column_exist(self.cursor, 'responses', 'new_desc')
+        )
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/migrations/008_add_desc_to_responses_up.py
+++ b/tests/migrations/008_add_desc_to_responses_up.py
@@ -24,12 +24,12 @@ class UpTest(unittest.TestCase):
 
     def test_response_hist_old_desc_exists(self):
         self.assertTrue(
-            helper.check_if_column_exist(self.cursor, 'responses', 'old_desc')
+            helper.check_if_column_exist(self.cursor, 'response_histories', 'old_desc')
         )
 
     def test_response_hist_new_desc_exists(self):
         self.assertTrue(
-            helper.check_if_column_exist(self.cursor, 'responses', 'new_desc')
+            helper.check_if_column_exist(self.cursor, 'response_histories', 'new_desc')
         )
 
 

--- a/tests/migrations/008_add_desc_to_responses_up.py
+++ b/tests/migrations/008_add_desc_to_responses_up.py
@@ -1,0 +1,27 @@
+import unittest
+import helper
+
+
+class UpTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.connection = helper.setup_connection()
+        cls.cursor = cls.connection.cursor()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.cursor.close()
+        cls.connection.rollback()
+        helper.teardown_connection(cls.connection)
+
+    def tearDown(self):
+        self.connection.rollback()
+
+    def test_response_desc_exists(self):
+        self.assertTrue(
+            helper.check_if_column_exist(self.cursor, 'responses', 'description')
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Response descriptions will be notes that moderators can use to share relevant tidbits of information on a particular response, such as where it's used, problems with it in the past, formatting notes, and what substitutions it supports