### PR TITLE
Drop email verified fields on user demographic history

### DIFF
--- a/docs/audit/user_demographic_history.md
+++ b/docs/audit/user_demographic_history.md
@@ -20,8 +20,6 @@ arbitrary value (typically null or false) if `purged_at` is set.
  changed_by_user_id  | integer                     |           | not null |                                                      | plain    |              |
  old_email           | text                        |           |          |                                                      | extended |              |
  new_email           | text                        |           |          |                                                      | extended |              |
- old_email_verified  | boolean                     |           | not null |                                                      | plain    |              |
- new_email_verified  | boolean                     |           | not null |                                                      | plain    |              |
  old_name            | text                        |           |          |                                                      | extended |              |
  new_name            | text                        |           |          |                                                      | extended |              |
  old_street_address  | text                        |           |          |                                                      | extended |              |

--- a/src/migrations/017_remove_verified_from_demo_hist.py
+++ b/src/migrations/017_remove_verified_from_demo_hist.py
@@ -1,0 +1,37 @@
+"""Drops the email verified fields on user demographic history"""
+
+
+def up(conn, cursor):
+    cursor.execute(
+        '''
+        ALTER TABLE user_demographic_history
+            DROP COLUMN old_email_verified
+        '''
+    )
+    print(cursor.query.decode('utf-8'))
+
+    cursor.execute(
+        '''
+        ALTER TABLE user_demographic_history
+            DROP COLUMN new_email_verified
+        '''
+    )
+    print(cursor.query.decode('utf-8'))
+
+
+def down(conn, cursor):
+    cursor.execute(
+        '''
+        ALTER TABLE user_demographic_history
+            ADD COLUMN old_email_verified BOOLEAN NULL
+        '''
+    )
+    print(cursor.query.decode('utf-8'))
+
+    cursor.execute(
+        '''
+        ALTER TABLE user_demographic_history
+            ADD COLUMN new_email_verified BOOLEAN NULL
+        '''
+    )
+    print(cursor.query.decode('utf-8'))

--- a/tests/migrations/017_remove_verified_from_demo_hist_down.py
+++ b/tests/migrations/017_remove_verified_from_demo_hist_down.py
@@ -1,0 +1,40 @@
+import unittest
+import helper
+
+
+class DownTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.connection = helper.setup_connection()
+        cls.cursor = cls.connection.cursor()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.cursor.close()
+        cls.connection.rollback()
+        helper.teardown_connection(cls.connection)
+
+    def tearDown(self):
+        self.connection.rollback()
+
+    def test_old_email_verified_exists(self):
+        self.assertTrue(
+            helper.check_if_column_exist(
+                self.cursor,
+                'user_demographic_history',
+                'old_email_verified'
+            )
+        )
+
+    def test_new_email_verified_exists(self):
+        self.assertTrue(
+            helper.check_if_column_exist(
+                self.cursor,
+                'user_demographic_history',
+                'new_email_verified'
+            )
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/migrations/017_remove_verified_from_demo_hist_up.py
+++ b/tests/migrations/017_remove_verified_from_demo_hist_up.py
@@ -1,0 +1,41 @@
+import unittest
+import helper
+
+
+class UpTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.connection = helper.setup_connection()
+        cls.cursor = cls.connection.cursor()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.cursor.close()
+        cls.connection.rollback()
+        helper.teardown_connection(cls.connection)
+
+    def tearDown(self):
+        self.connection.rollback()
+
+    def test_old_email_verified_dne(self):
+        self.assertFalse(
+            helper.check_if_column_exist(
+                self.cursor,
+                'user_demographic_history',
+                'old_email_verified'
+            )
+        )
+
+    def test_new_email_verified_dne(self):
+        self.assertFalse(
+            helper.check_if_column_exist(
+                self.cursor,
+                'user_demographic_history',
+                'new_email_verified'
+            )
+        )
+
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/migrations/017_remove_verified_from_demo_hist_up.py
+++ b/tests/migrations/017_remove_verified_from_demo_hist_up.py
@@ -36,6 +36,5 @@ class UpTest(unittest.TestCase):
         )
 
 
-
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Verifying emails would require either a paid service or a lot of user reports since it'll go to spam as this would be the only email coming from redditloans.com, so decided not to verify emails. Since inputting an email is entirely voluntarily I figure odds of fake emails is much lower than normal, and fake emails are no worse than just not putting an email in